### PR TITLE
Throw error on connection close

### DIFF
--- a/lib/subscribe.js
+++ b/lib/subscribe.js
@@ -5,6 +5,10 @@ module.exports = function Subscribe(url, opts) {
     Channel(url, opts, function (err, ch, conn) {
       if (err) throw err;
 
+      conn.on('close', function (err) {
+        if (err) throw err;
+      });
+
       ch.assertExchange(ex, 'topic', {}, function (err) {
         if (err) throw err;
 


### PR DESCRIPTION
Throw an error in subscribe method when AMQP connection is closed.